### PR TITLE
Center the About modal tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
             <h4 class="modal-title">Welcome to the BootLeaf template!</h4>
           </div>
           <div class="modal-body">
-            <ul class="nav nav-tabs" id="aboutTabs">
+            <ul class="nav nav-tabs nav-justified" id="aboutTabs">
               <li class="active"><a href="#about" data-toggle="tab"><i class="fa fa-question-circle"></i>&nbsp;About the project</a></li>
               <li><a href="#contact" data-toggle="tab"><i class="fa fa-envelope"></i>&nbsp;Contact us</a></li>
               <li><a href="#disclaimer" data-toggle="tab"><i class="fa fa-exclamation-circle"></i>&nbsp;Disclaimer</a></li>


### PR DESCRIPTION
Hi Bryan,

I added `nav-justified` to center the About modal tabs for aesthetics on all resolutions, but in particular to improve the look on mobile devices.

**For example, the current look and feel of the design is as follows:**

*Desktop:*
<img width="885" alt="Bootleaf Desktop Before PR" src="https://cloud.githubusercontent.com/assets/5023024/12214142/7eba2470-b64e-11e5-890e-3a7d21f9b3af.png">

*Mobile (shown on `xs` devices):*
<img width="274" alt="Bootleaf Mobile Before PR" src="https://cloud.githubusercontent.com/assets/5023024/12214141/7eb9d90c-b64e-11e5-886d-cb7e2fb8654b.png">

**This pull request would make the following changes to the design:**

*Desktop:*
<img width="884" alt="Bootleaf Desktop Pull Request" src="https://cloud.githubusercontent.com/assets/5023024/12214143/7ebb5c46-b64e-11e5-8569-398993aba8b8.png">

*Mobile (shown on `xs` devices):*
<img width="262" alt="Bootleaf Mobile Pull Request" src="https://cloud.githubusercontent.com/assets/5023024/12214144/7ebbc0fa-b64e-11e5-915b-7a09c140442d.png">

Best,
Kitty

P.S. :heart: this app!