### PR TITLE
Center nav on small devices.

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -162,8 +162,11 @@ input[type="radio"], input[type="checkbox"] {
     -webkit-hyphens: auto;
       hyphens: auto;
   }
-  .dropdown-menu a i{
+  .dropdown-menu a{
     color: #FFFFFF;
+    text-align: justify;
+    margin: 0 auto;
+    width: 15em;
   }
 }
 /* Print Handling */

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
                 <span id="searchicon" class="fa fa-search form-control-feedback"></span>
             </div>
           </form>
-          <ul class="nav navbar-nav">
+          <ul class="nav navbar-nav text-center">
             <li><a href="#" data-toggle="collapse" data-target=".navbar-collapse.in" id="about-btn"><i class="fa fa-question-circle white"></i>&nbsp;&nbsp;About</a></li>
             <li class="dropdown">
               <a id="toolsDrop" href="#" role="button" class="dropdown-toggle" data-toggle="dropdown"><i class="fa fa-globe white"></i>&nbsp;&nbsp;Tools <b class="caret"></b></a>


### PR DESCRIPTION
This PR centers the navigation and dropdown menu on smaller devices (phones specifically).

**The current look on small devices:**  

<img width="643" alt="Before pull request implementation" src="https://cloud.githubusercontent.com/assets/5023024/17280276/f6e017c6-5751-11e6-8f13-bd6f8cb7f362.png">  

**The proposed look on small devices:**   

<img width="643" alt="After pull request implementation" src="https://cloud.githubusercontent.com/assets/5023024/17280277/f95d3bc8-5751-11e6-9613-b04b68941cbd.png">  

The proposed change will: 
- Add `text-center` to the `nav navbar-nav` class in the index.html
- Add center justification the dropdown menu in app.css.

_Note_: The proposed change affects the class in app.css as it changes from `.dropdown-menu a i` to `.dropdown-menu a`.
